### PR TITLE
Use correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Library for putting ATtiny25/45/85 to timed sleep in one line of code!
 paragraph=In one quick line of code, you can put an ATtiny25/45/85 to deep sleep for a custom length of time!
 category=Device Control
 url=https://github.com/connornishijima/TinySnore
-architectures=atmelavr
+architectures=avr


### PR DESCRIPTION
The previous value caused the example sketch to appear under **File > Examples > INCOMPATIBLE** even though a compatible board was selected and also caused the Arduino IDE to display the warning:
```
WARNING: library TinySnore claims to run on (atmelavr) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
every time a sketch is compiled that includes the TinySnore library.

Both the most popular ATtiny25/45/85 hardware packages ([SpenceKonde/ATTinyCore](https://github.com/SpenceKonde/ATTinyCore), [damellis/attiny](https://github.com/damellis/attiny), and likely any others) use `avr` as the architecture value.